### PR TITLE
chore(ci): add Claude Code review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,79 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [ opened, labeled ]
+  issue_comment:
+    types: [ created ]
+
+jobs:
+  claude-review:
+    if: |
+      (
+        (github.event_name == 'pull_request' && github.event.action == 'opened') ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude review')) ||
+        (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'ask-claude-review')
+      ) && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      - name: Get PR number
+        id: pr-number
+        run: |
+          if [ "${{ github.event_name }}" == "issue_comment" ]; then
+            echo "pr_number=${{ github.event.issue.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "pr_number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          fi
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ORGANIZATION_ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ steps.pr-number.outputs.pr_number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            POST YOUR REVIEW BY UPDATING AN EXISTING CODE REVIEW COMMENT if exists, or by CREATING A NEW COMMENT otherwise:
+
+            Step 1 - Find existing Claude review comment (REQUIRED):
+            COMMENT_ID=$(gh pr view ${{ steps.pr-number.outputs.pr_number }} --json comments --jq '.comments[] | select(.body | contains("## Claude Code Review")) | .id' | head -1)
+
+            Step 2 - Create your review markdown:
+            - Start with "## Claude Code Review" header (REQUIRED for identification)
+            - Add timestamp: "**Last updated:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+            - Include review counter if updating: "**Review iteration:** #N"
+            - Then provide your detailed review
+
+            Step 3 - ALWAYS update existing comment if it exists (MANDATORY):
+            if [ -n "$COMMENT_ID" ]; then
+              gh pr comment ${{ steps.pr-number.outputs.pr_number }} --edit-last --body "<your-review-markdown>"
+              echo "Updated existing review comment ID: $COMMENT_ID"
+            else
+              gh pr comment ${{ steps.pr-number.outputs.pr_number }} --body "<your-review-markdown>"
+              echo "Created initial review comment"
+            fi
+
+            IMPORTANT RULES:
+            1. NEVER create a new Claude Code Review comment if one exists - ALWAYS edit the existing one
+            2. Always start with "## Claude Code Review" for identification
+            3. Include timestamp to show when review was last updated
+            4. Prevent unwanted GitHub auto-linking and mentions
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,38 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ORGANIZATION_ANTHROPIC_API_KEY }}
+          additional_permissions: |
+            actions: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# Bonita Groovy Connector
+
+## Project Overview
+
+- **Name**: Bonita Groovy Connector
+- **Artifact**: `org.bonitasoft.connectors:bonita-connector-groovy`
+- **Version**: 1.1.5-SNAPSHOT
+- **Description**: Bonita connector that evaluates a Groovy script at runtime, with optional variable bindings passed in from the process context.
+- **License**: GPL-2.0
+- **Tech stack**: Java 11, Maven, Bonita Engine 7.14.0, Groovy 3.x (provided by Bonita runtime), JUnit 4, Mockito, AssertJ
+
+## Build Commands
+
+```bash
+# Full build with tests (default goal)
+./mvnw clean verify
+
+# Skip tests
+./mvnw clean verify -DskipTests
+
+# Run tests only
+./mvnw test
+
+# Check license headers (runs at validate phase automatically)
+./mvnw validate
+
+# Apply/format license headers
+./mvnw license:format
+
+# Package connector ZIP
+./mvnw clean package
+
+# Deploy to Maven Central (requires GPG key)
+./mvnw clean deploy -Pdeploy
+```
+
+The build produces:
+- `target/bonita-connector-groovy-<version>.jar`
+- `target/bonita-connector-groovy-<version>-*.zip` — Bonita connector assembly
+
+## Architecture
+
+### Class hierarchy
+
+```
+AbstractConnector (bonita-common)
+  └── GroovyScriptConnector    # Single connector class; the entire implementation
+```
+
+### Key patterns
+
+- **Minimal surface area**: The entire connector is one class (`GroovyScriptConnector`).
+- **Script evaluation**: Uses `groovy.lang.GroovyShell` with a `Binding` populated from the `variables` input parameter (a `List<List<Object>>` of key-value pairs).
+- **API accessor injection**: If a variable key matches `ExpressionConstants.API_ACCESSOR`, the Bonita `APIAccessor` is injected into the binding rather than a plain value.
+- **Input parameters**:
+  - `script` (String) — the Groovy script text; mandatory.
+  - `variables` (List<List<Object>>) — optional list of `[name, value]` pairs bound into the script.
+- **Output parameter**: `result` (Object) — the return value of the evaluated script.
+- **License check**: `license-maven-plugin` enforces the GPL header on all `.java` files at the `validate` phase.
+- **Resources**: Connector `.def` and `.impl` descriptors in `src/main/resources-filtered/`, filtered with Maven properties at build time.
+
+## Testing Strategy
+
+- Framework: JUnit 4 + AssertJ + Mockito
+- Tests verify script execution, variable binding, API accessor injection, and null-script validation.
+- No external services required; `GroovyShell` is exercised directly.
+- Coverage enforced via JaCoCo.
+- SonarCloud project key: `bonitasoft_bonita-connector-groovy`.
+
+## Commit Message Format
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <short description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Common types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `ci`.
+
+Examples:
+```
+fix: propagate GroovyRuntimeException as ConnectorException
+chore: bump Bonita engine to 7.15.0
+test: add test for API accessor injection in binding
+```
+
+## Release Process
+
+1. Remove `-SNAPSHOT` from `version` in `pom.xml`.
+2. Update `groovy.def.version` if the connector definition changed.
+3. Commit: `chore: release X.Y.Z`.
+4. Tag: `git tag X.Y.Z`.
+5. Deploy to Maven Central: `./mvnw clean deploy -Pdeploy` (requires GPG key and Central credentials in `~/.m2/settings.xml`).
+6. Push tag: `git push origin X.Y.Z`.
+7. Bump to next `-SNAPSHOT` and commit: `chore: prepare next development iteration`.


### PR DESCRIPTION
## Summary
- Add automated Claude Code PR review workflow (`claude-code-review.yml`)
- Add interactive `@claude` workflow (`claude.yml`)
- Add project-specific `CLAUDE.md` for AI-assisted development context

## Details
- Auto-review triggers on PR open, `@claude review` comment, or `ask-claude-review` label
- Interactive mode responds to `@claude` mentions in issues, PR comments, and reviews
- Uses org-level `ORGANIZATION_ANTHROPIC_API_KEY` secret
- Based on the mature workflow from `bonita-connector-ai`

## Test plan
- [ ] Verify workflows appear in Actions tab after merge
- [ ] Test auto-review by opening a test PR
- [ ] Test interactive mode with `@claude` comment

Generated with [Claude Code](https://claude.com/claude-code)